### PR TITLE
Use a fixture with a default project in test functions to speed up testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,9 @@ def copier_project_defaults():
         "license": "MIT",
         "copyright_statement": "2025, The pyfar developers",
         }
+
+@pytest.fixture(scope="session")
+def default_project(copie_session, copier_project_defaults):
+    project = copie_session.copy(
+        extra_answers=copier_project_defaults)
+    return project

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -1,11 +1,5 @@
 import pytest
 
-@pytest.fixture(scope="session")
-def default_project(copie_session, copier_project_defaults):
-    project = copie_session.copy(
-        extra_answers=copier_project_defaults)
-    return project
-
 def test_project_folder(default_project):
     assert default_project.exit_code == 0
     assert default_project.exception is None


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #15

### Changes proposed in this pull request:

- Added new fixture `default_project` to prevent a new project from being created for each new test.
- Adjusted existing test functions so that `default_project` is used as a parameter instead of creating new projects.
- The functions `test_content_license()` and `test_license_choice_other()` remained unchanged since they require `extra_answers` other than those contained in `default_project`. 
