### PR TITLE
Add new parameter `python_versions` in copier.yml

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -51,14 +51,14 @@ keywords:
 python_versions:
   when: false
   type: yaml
-  default: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']
+  default: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
 minimum_python_version:
-    type: yaml
+    type: str
     help: "The minimum Python version required"
     choices: >
         {% for v in python_versions %}
-            - "'{{ v }}'"
+            - "{{ v }}"
         {% endfor %}
 
 _subdirectory: "template"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ def copier_project_defaults():
         "project_long_description": "my_project_description",
         "project_getting_started": "This is how to get started.",
         "git_username": "pyfar",
-        "minimum_python_version": "'3.11'",
+        "minimum_python_version": "3.11",
         "license": "MIT",
         "copyright_statement": "2025, The pyfar developers",
         "project_short_description": "my_project_short_description",


### PR DESCRIPTION
I noticed that for parameters related to Python versions, we create a new array with Python versions in several places. Later, this will require us to manually add new or remove old Python versions in each of these arrays. 
To avoid this, we can add a new parameter that defines all available Python versions once and use it in all other parameters related to Python versions.

### Changes proposed in this pull request:

- Added a new parameter called `python_versions` to copier.yml, which defines all Python versions valid for the project. 
- The choices for the `minimum_python_version` parameter are now created from the new `python_versions` parameter.
- The parameter `valid_python_versions` now also uses the new parameter `python_versions` to define the array of all available Python versions. 
- Adjusted the `conftest.py` file, since the Python versions are now stored with obligatory apostrophes ' ' as follows:      
` "minimum_python_version": "'3.11'",`
