### PR TITLE
Add a parameter for custom MANIFESTs

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -118,6 +118,13 @@ use_pypi_deployment_with_ci:
         Would you like to add a CircleCI workflow for continuous deployment to PyPI?
     default: true
 
+manifest_custom:
+    type: str
+    help: |
+        Enter a comma-separated list of MANIFEST.in directives to include or exclude files and directories.
+        Each entry should follow standard MANIFEST.in syntax.
+    default: "recursive-include your/custom/path/, recursive-exclude another/custom/path/"
+
 valid_python_versions:
   when: false
   type: yaml

--- a/copier.yml
+++ b/copier.yml
@@ -123,7 +123,7 @@ manifest_custom:
     help: |
         Enter a comma-separated list of MANIFEST.in directives to include or exclude files and directories.
         Each entry should follow standard MANIFEST.in syntax.
-
+    default: ""
 valid_python_versions:
   when: false
   type: yaml

--- a/copier.yml
+++ b/copier.yml
@@ -123,7 +123,6 @@ manifest_custom:
     help: |
         Enter a comma-separated list of MANIFEST.in directives to include or exclude files and directories.
         Each entry should follow standard MANIFEST.in syntax.
-    default: "recursive-include your/custom/path/, recursive-exclude another/custom/path/"
 
 valid_python_versions:
   when: false

--- a/template/MANIFEST.in.jinja
+++ b/template/MANIFEST.in.jinja
@@ -8,3 +8,7 @@ recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
+
+{%- for key in manifest_custom.split(',') %}
+{{ key.strip() }}
+{%- endfor %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ def copier_project_defaults():
         "copyright_statement": "2025, The pyfar developers",
         "project_short_description": "my_project_short_description",
         "python_versions": "['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']",
+        "manifest_custom": "recursive-include your/custom/path/,"
+        "recursive-exclude another/custom/path/'",
         }
 
 @pytest.fixture(scope="session")

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -177,6 +177,7 @@ def test_content_readthedocs(default_project, desired):
                                     ".readthedocs.yml").read_text()
     assert desired in content
 
+
 @pytest.mark.parametrize("desired", [
     'docs/resources/logos/pyfar_logos_fixed_size_my_project.png',
     'your/custom/path/',
@@ -198,4 +199,14 @@ def test_content_circleci(default_project, desired):
     content = default_project.project_dir.joinpath(
                                     ".circleci/config.yml").read_text()
     print(content)
+    assert desired in content
+
+
+@pytest.mark.parametrize("desired", [
+    'recursive-include your/custom/path/\n'
+    'recursive-exclude another/custom/path/',
+])
+def test_content_MANIFEST(default_project, desired):
+    content = default_project.project_dir.joinpath(
+                                    "MANIFEST.in").read_text()
     assert desired in content


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #47

### Changes proposed in this pull request:

- Add a new parameter called `manifest_custom` to the copier.yml file
- Adjust the `template/MANIFEST.in` file so that it includes custom directives from the `manifest_custom` parameter
- Adjust the `test_copier.file` to test whether the custom directives are actually present in the file
