### PR TITLE
do not publish tempalte on pypi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,20 +253,3 @@ workflows:
             # only act on version tags
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
-
-      - run_pypi_publish:
-          matrix:
-            parameters:
-              version:
-                - "3.13"
-          requires:
-            - build_and_test
-            - ruff
-            - test_documentation_build
-            - test_deprecation_warnings
-          filters:
-            branches:
-              ignore: /.*/
-            # only act on version tags
-            tags:
-              only: /^v[0-9]+(\.[0-9]+)*$/


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #3

### Changes proposed in this pull request:

- remove publish to pypi, we dont need it, we just need a tag, so that copier can know the version.
