### PR TITLE
Remove unnecessary line from .gitignore

### DIFF
--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -125,7 +125,6 @@ docs/resources/logos/pyfar_logos_fixed_size_pyfar.png
 docs/{{ logo_path_gallery }}
 
 # custom 
-{{ pypi_license_classifier }}
 {%- for key in gitignore_custom.split(',') %}
 {{ key.strip() }}
 {%- endfor %}


### PR DESCRIPTION
This is one of many upcoming PRs that aim to adjust the template to existing packages. 

### Changes proposed in this pull request:

- Removed unnecessary line containing `pypi_license_classifier` from the .gitignore file
