### PR TITLE
Add `sphinx_copybutton` to the `docs/conf.py` and `pyproject.toml`

### DIFF
--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -31,6 +31,7 @@ extensions = [
     'sphinx_favicon',
     'sphinx_reredirects',
     'sphinx_mdinclude',
+    'sphinx_copybutton',
 ]
 
 # show tocs for classes and functions of modules using the autodocsumm

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -55,6 +55,7 @@ docs = [
     "sphinx-design",
     "sphinx-favicon",
     "sphinx-reredirects",
+    "sphinx-copybutton",
 ]
 dev = ["{{ project_slug }}[deploy,tests,docs]"]
 


### PR DESCRIPTION
This is one of many upcoming PRs that aim to adjust the template to existing packages.

### Changes proposed in this pull request:

- Add the extension `sphinx_copybutton` to the `docs/conf.py` and `pyproject.toml`
