### PR TITLE
Add the parameter `intersphinx_mapping` to the copier.yml

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -85,6 +85,22 @@ copyright_statement:
     help: "What is the copyright statement? For example publication year, copyright holder."
     default: "{{ '%Y' | strftime }}, {{ author }}"
 
+intersphinx_mapping:
+  type: yaml
+  help: "Select projects which should be cross-referenced in the documentation."
+  choices:
+    - numpy
+    - scipy
+    - matplotlib
+    - pyfar
+    - gallery
+    - spharpy
+    - soundfile
+  multiselect: true
+  default:
+    - numpy
+    - gallery
+
 dependencies:
     type: str
     help: |

--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -93,15 +93,20 @@ highlight_language = "python3"
 
 # intersphinx mapping
 intersphinx_mapping = {
-    {% if 'numpy' in dependencies -%}
+    {%- if 'numpy' in intersphinx_mapping %}
     'numpy': ('https://numpy.org/doc/stable/', None),{% endif %}
-    {% if 'scipy' in dependencies -%}
+    {%- if 'scipy' in intersphinx_mapping %}
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),{% endif %}
-    {% if 'matplotlib' in dependencies -%}
+    {%- if 'matplotlib' in intersphinx_mapping %}
     'matplotlib': ('https://matplotlib.org/stable/', None),{% endif %}
-    {% if 'pyfar' in dependencies -%}
-    'pyfar': ('https://pyfar.readthedocs.io/en/stable/', None),
+    {%- if 'pyfar' in intersphinx_mapping %}
+    'pyfar': ('https://pyfar.readthedocs.io/en/stable/', None),{% endif %}
+    {%- if 'gallery' in intersphinx_mapping %}
     'gallery': ('https://pyfar-gallery.readthedocs.io/en/latest/', None),{% endif %}
+    {%- if 'soundfile' in intersphinx_mapping %}
+    'soundfile': ('https://python-soundfile.readthedocs.io/en/latest/', None),{% endif %}
+    {%- if 'spharpy' in intersphinx_mapping %}
+    'spharpy': ('https://spharpy.readthedocs.io/en/stable/', None),{% endif %}
     }
 
 # -- Options for HTML output -------------------------------------------------


### PR DESCRIPTION
This is one of many upcoming PRs that aim to adjust the template to existing packages.

### Changes proposed in this pull request:

- Add the new `intersphinx_mapping` parameter with multiple-choice answers to the `copier.yml` file
- Adjust the `docs/conf.py` file so that cross-references to more different projects are possible
