### PR TITLE
fix a bug in the .readthedocs.yml file

### DIFF
--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -10,10 +10,10 @@ build:
   os: ubuntu-24.04
   tools:
     python: "{{ latest_python_version }}"
-{% if 'libsndfile1' in apt_packages -%}
+  {% if 'libsndfile1' in apt_packages -%}
   apt_packages:
     - libsndfile1
-{%- endif %}
+  {%- endif %}
 
 {%- if add_submodules == true %}
 

--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -10,10 +10,12 @@ build:
   os: ubuntu-24.04
   tools:
     python: "{{ latest_python_version }}"
+  {%- if apt_packages != "" %}
   apt_packages:
     {%- for package in apt_packages.split(',') %}
     - {{ package.strip() }}
     {%- endfor %}
+  {%- endif %}
 
 {%- if add_submodules == true %}
 

--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -10,10 +10,10 @@ build:
   os: ubuntu-24.04
   tools:
     python: "{{ latest_python_version }}"
-  {% if 'libsndfile1' in apt_packages -%}
   apt_packages:
-    - libsndfile1
-  {%- endif %}
+    {%- for package in apt_packages.split(',') %}
+    - {{ package.strip() }}
+    {%- endfor %}
 
 {%- if add_submodules == true %}
 

--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: {{ latest_python_version }}
+    python: "{{ latest_python_version }}"
 {% if 'libsndfile1' in apt_packages -%}
   apt_packages:
     - libsndfile1

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -176,7 +176,7 @@ def test_content_docs_multiple_files(default_project, file_name):
 
 @pytest.mark.parametrize("desired", [
     '- libsndfile1',
-    "python: 3.14",
+    'python: "3.14"',
     "  include:\n    - path/to/submodule",
 ])
 def test_content_readthedocs(default_project, desired):

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -186,6 +186,15 @@ def test_content_readthedocs(default_project, desired):
     assert desired in content
 
 
+def test_apt_packages_empty(copie, copier_project_defaults):
+    project = copie.copy(extra_answers={**copier_project_defaults,
+                                         "apt_packages": ""})
+    content = project.project_dir.joinpath(
+                                    ".readthedocs.yml").read_text()
+    not_desired = '  apt_packages:\n    -'
+    assert not_desired not in content
+
+
 @pytest.mark.parametrize("desired", [
     'docs/resources/logos/pyfar_logos_fixed_size_my_project.png',
     'your/custom/path/',

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -175,8 +175,9 @@ def test_content_docs_multiple_files(default_project, file_name):
 
 
 @pytest.mark.parametrize("desired", [
-    '- libsndfile1',
-    'python: "3.14"',
+    '  apt_packages:\n'
+    '    - libsndfile1',
+    '    python: "3.14"',
     "  include:\n    - path/to/submodule",
 ])
 def test_content_readthedocs(default_project, desired):


### PR DESCRIPTION
The test for Read the Docs failed in the [PR#927](https://github.com/pyfar/pyfar/pull/927) of the pyfar package because the python version in the tools in the `.readthedocs.yml` file was not enclosed in quotation marks.

### Changes proposed in this pull request:

- Enclose `{{ latest_python_version }}` in the quotation marks
- Adjust the test function in the `test_copier.py` file