### PR TITLE
Add submodule parameters to the template

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -148,17 +148,10 @@ docs_custom_import:
         Separate multiple modules with commas.
     default: ""
 
-
 add_submodules:
     type: bool
     help: "Would you like to add submodules to this project?"
     default: false
-
-submodule_description:
-    when: "{{ add_submodules }}"
-    type: str
-    help: "Enter the short description for the submodule. This will be added as a comment in the .readthedocs.yml file."
-    default: ""
 
 submodule_path:
     when: "{{ add_submodules }}"

--- a/copier.yml
+++ b/copier.yml
@@ -148,6 +148,24 @@ docs_custom_import:
         Separate multiple modules with commas.
     default: ""
 
+
+add_submodules:
+    type: bool
+    help: "Would you like to add submodules to this project?"
+    default: false
+
+submodule_description:
+    when: "{{ add_submodules }}"
+    type: str
+    help: "Enter the short description for the submodule. This will be added as a comment in the .readthedocs.yml file."
+    default: ""
+
+submodule_path:
+    when: "{{ add_submodules }}"
+    type: str
+    help: "Enter the path for the submodule."
+    default: ""
+
 valid_python_versions:
   when: false
   type: yaml

--- a/template/.circleci/config.yml.jinja
+++ b/template/.circleci/config.yml.jinja
@@ -44,6 +44,11 @@ jobs:
       - run:
           name: install dependencies
           command: pip install ".[tests]"
+      {%- if add_submodules == true %}
+      - run:
+          name: synchronize submodules
+          command: git submodule update --init --recursive && git submodule update --recursive --init
+      {%- endif %}
       - run:
           name: Run tests
           command: pytest tests
@@ -62,6 +67,11 @@ jobs:
       - run:
           name: install dependencies
           command: pip install ".[tests]"
+      {%- if add_submodules == true %}
+      - run:
+          name: synchronize submodules
+          command: git submodule update --init --recursive && git submodule update --recursive --init
+      {%- endif %}
       - run:
           name: Ruff
           command: ruff check
@@ -85,6 +95,10 @@ jobs:
       - run:
           name: Sphinx
           command: |
+            {%- if add_submodules == true %}
+            git submodule sync --recursive
+            git submodule update --recursive --init
+            {%- endif %}
             pip install ".[docs]"
             cd docs/
             make html SPHINXOPTS="-W"
@@ -110,6 +124,11 @@ jobs:
           command: pip install ".[tests]"
       - run: |
           python --version
+      {%- if add_submodules == true %}
+      - run:
+          name: synchronize submodules
+          command: git submodule update --init --recursive && git submodule update --recursive --init
+      {%- endif %}
       - run:
           name: Run tests
           command: pytest tests -W error::DeprecationWarning
@@ -161,6 +180,10 @@ jobs:
       - run:
           name: deploy
           command: |  # create whl, install twine and publish to Test PyPI
+            {%- if add_submodules == true %}
+            git submodule sync --recursive
+            git submodule update --recursive --init
+            {%- endif %}
             python -m build
             twine check dist/*
             twine upload dist/*

--- a/template/.circleci/config.yml.jinja
+++ b/template/.circleci/config.yml.jinja
@@ -178,13 +178,14 @@ jobs:
       - run:
           name: install dependencies
           command: pip install ".[deploy]"
+      {%- if add_submodules == true %}
+      - run:
+          name: synchronize submodules
+          command: git submodule sync --recursive && git submodule update --recursive --init
+      {%- endif %}
       - run:
           name: deploy
           command: |  # create whl, install twine and publish to Test PyPI
-            {%- if add_submodules == true %}
-            git submodule sync --recursive
-            git submodule update --recursive --init
-            {%- endif %}
             python -m build
             twine check dist/*
             twine upload dist/*

--- a/template/.circleci/config.yml.jinja
+++ b/template/.circleci/config.yml.jinja
@@ -47,7 +47,7 @@ jobs:
       {%- if add_submodules == true %}
       - run:
           name: synchronize submodules
-          command: git submodule update --init --recursive && git submodule update --recursive --init
+          command: git submodule sync --recursive && git submodule update --recursive --init
       {%- endif %}
       - run:
           name: Run tests
@@ -70,7 +70,7 @@ jobs:
       {%- if add_submodules == true %}
       - run:
           name: synchronize submodules
-          command: git submodule update --init --recursive && git submodule update --recursive --init
+          command: git submodule sync --recursive && git submodule update --recursive --init
       {%- endif %}
       - run:
           name: Ruff
@@ -92,13 +92,14 @@ jobs:
           name: Install System Dependencies
           command: sudo apt-get update && sudo apt-get install -y libsndfile1
       {%- endif %}
+      {%- if add_submodules == true %}
+      - run:
+          name: synchronize submodules
+          command: git submodule sync --recursive && git submodule update --recursive --init
+      {%- endif %}
       - run:
           name: Sphinx
           command: |
-            {%- if add_submodules == true %}
-            git submodule sync --recursive
-            git submodule update --recursive --init
-            {%- endif %}
             pip install ".[docs]"
             cd docs/
             make html SPHINXOPTS="-W"
@@ -127,7 +128,7 @@ jobs:
       {%- if add_submodules == true %}
       - run:
           name: synchronize submodules
-          command: git submodule update --init --recursive && git submodule update --recursive --init
+          command: git submodule sync --recursive && git submodule update --recursive --init
       {%- endif %}
       - run:
           name: Run tests

--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -17,7 +17,7 @@ build:
 
 {%- if add_submodules == true %}
 
-# {{ submodule_description }}
+# make sure to include submodule at {{ submodule_path }}
 submodules:
   include:
     - {{ submodule_path }}

--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -15,6 +15,14 @@ build:
     - libsndfile1
 {%- endif %}
 
+{%- if add_submodules == true %}
+
+# {{ submodule_description }}
+submodules:
+  include:
+    - {{ submodule_path }}
+{%- endif %}
+
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/template/CONTRIBUTING.rst.jinja
+++ b/template/CONTRIBUTING.rst.jinja
@@ -45,6 +45,10 @@ extensions in `Visual Studio Code <https://code.visualstudio.com/>`_ ...
     $ git clone https://github.com/YOUR_USERNAME/{{ project_slug }}.git
     $ cd {{ project_slug }}
 
+   Note that some graphical Git interfaces can not do the recursive clone. If the folder {{ submodule_path }} is empty try::
+
+    $ git submodule update --init
+
 3. Install your local copy into a virtualenv. Assuming you have Anaconda or Miniconda installed, this is how you set up your fork for local development::
 
     $ conda create --name {{ project_slug }} python
@@ -74,5 +78,19 @@ extensions in `Visual Studio Code <https://code.visualstudio.com/>`_ ...
 
 7. Submit a pull request on the develop branch through the GitHub website.
 
+{%- if add_submodules == true %}
+
+Submodules
+~~~~~~~~~~
+
+To update the submodule containing the conventions and verification rules run
+
+.. code-block:: bash
+
+    $ git submodule update --init --recursive
+    $ git submodule update --recursive --remote
+
+and then commit the changes
+{%- endif %}
 
 .. _general contributing guidelines: https://pyfar-gallery.readthedocs.io/en/latest/contribute/index.html

--- a/template/CONTRIBUTING.rst.jinja
+++ b/template/CONTRIBUTING.rst.jinja
@@ -45,9 +45,12 @@ extensions in `Visual Studio Code <https://code.visualstudio.com/>`_ ...
     $ git clone https://github.com/YOUR_USERNAME/{{ project_slug }}.git
     $ cd {{ project_slug }}
 
+   {%- if add_submodules == true %}
+   
    Note that some graphical Git interfaces can not do the recursive clone. If the folder {{ submodule_path }} is empty try::
 
     $ git submodule update --init
+    {%- endif %}
 
 3. Install your local copy into a virtualenv. Assuming you have Anaconda or Miniconda installed, this is how you set up your fork for local development::
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@ def copier_project_defaults():
         "manifest_custom": "recursive-include your/custom/path/,"
         "recursive-exclude another/custom/path/'",
         "docs_custom_import": "module, anothermodule",
+        "add_submodules": "true",
+        "submodule_description": "include this submodule",
+        "submodule_path": "path/to/submodule",
         }
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,6 @@ def copier_project_defaults():
         "recursive-exclude another/custom/path/'",
         "docs_custom_import": "module, anothermodule",
         "add_submodules": "true",
-        "submodule_description": "include this submodule",
         "submodule_path": "path/to/submodule",
         }
 

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -198,8 +198,6 @@ def test_content_gitignore(default_project, desired):
     '                - "3.13"\n                - "3.14"',
     'command: sudo apt-get update && sudo apt-get install -y libsndfile1',
     '# Test and publish on new git version tags',
-    'git submodule sync --recursive\n            '
-    'git submodule update --recursive --init',
     'name: synchronize submodules',
 ])
 def test_content_circleci(default_project, desired):

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -174,7 +174,6 @@ def test_content_docs_multiple_files(default_project, file_name):
 @pytest.mark.parametrize("desired", [
     '- libsndfile1',
     "python: 3.14",
-    "# include this submodule",
     "  include:\n    - path/to/submodule",
 ])
 def test_content_readthedocs(default_project, desired):

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -83,6 +83,7 @@ def test_license_choice_other(copie, copier_project_defaults):
 @pytest.mark.parametrize("desired", [
     "https://github.com/pyfar/my_project/issues",
     "$ cd my_project",
+    "$ git submodule update --init --recursive",
 ])
 def test_content_contributing(default_project, desired):
     content = default_project.project_dir.joinpath(
@@ -173,6 +174,8 @@ def test_content_docs_multiple_files(default_project, file_name):
 @pytest.mark.parametrize("desired", [
     '- libsndfile1',
     "python: 3.14",
+    "# include this submodule",
+    "  include:\n    - path/to/submodule",
 ])
 def test_content_readthedocs(default_project, desired):
     content = default_project.project_dir.joinpath(
@@ -196,6 +199,9 @@ def test_content_gitignore(default_project, desired):
     '                - "3.13"\n                - "3.14"',
     'command: sudo apt-get update && sudo apt-get install -y libsndfile1',
     '# Test and publish on new git version tags',
+    'git submodule sync --recursive\n            '
+    'git submodule update --recursive --init',
+    'name: synchronize submodules',
 ])
 def test_content_circleci(default_project, desired):
     content = default_project.project_dir.joinpath(


### PR DESCRIPTION
This PR should cover the implementation of submodules introduced in the [sofar](https://github.com/pyfar/sofar) package.

### Changes proposed in this pull request:

- Add new parameters to include submodules in the project.
- Add submodule implementation to the files `.circleci/config.yml`, `CONTRIBUTING.rst` and `.readthedocs.yml`
- Modify `conftest.py` and `test_copier.py` to check for the existence of the new content