### PR TITLE
Add a parameter for custom Binder path in README.md

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -174,12 +174,12 @@ submodule_path:
 
 
 introduction_path:
-    type: str
+    type: yaml
     help: |
         If you have an introduction notebook in Jupyter, you can specify the path to it here. 
         It will be included in the README.md. 
         Please leave it empty if you do not want to include an introduction notebook.
-    default: ""
+    default: docs/gallery/interactive/{{ project_slug }}_introduction.ipynb
 
 valid_python_versions:
   when: false

--- a/copier.yml
+++ b/copier.yml
@@ -172,6 +172,15 @@ submodule_path:
     help: "Enter the path for the submodule."
     default: ""
 
+
+introduction_path:
+    type: str
+    help: |
+        If you have an introduction notebook in Jupyter, you can specify the path to it here. 
+        It will be included in the README.md. 
+        Please leave it empty if you do not want to include an introduction notebook.
+    default: ""
+
 valid_python_versions:
   when: false
   type: yaml

--- a/copier.yml
+++ b/copier.yml
@@ -172,14 +172,13 @@ submodule_path:
     help: "Enter the path for the submodule."
     default: ""
 
-
 introduction_path:
-    type: yaml
+    type: str
     help: |
         If you have an introduction notebook in Jupyter, you can specify the path to it here. 
         It will be included in the README.md. 
         Please leave it empty if you do not want to include an introduction notebook.
-    default: docs/gallery/interactive/{{ project_slug }}_introduction.ipynb
+    default: "docs/gallery/interactive/{{ project_slug }}_introduction.ipynb"
 
 valid_python_versions:
   when: false

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -6,7 +6,7 @@
 [![Documentation Status](https://readthedocs.org/projects/{{ project_slug }}/badge/?version=latest)](https://{{ project_slug }}.readthedocs.io/en/latest/?badge=latest)
 [![CircleCI](https://circleci.com/gh/{{ git_username }}/{{ project_slug | replace("_", "-") }}.svg?style=shield)](https://circleci.com/gh/{{ git_username }}/{{ project_slug | replace("_", "-") }})
 {%- if introduction_path != "" %}
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyfar/gallery/main?labpath=docs/gallery/interactive/{{ introduction_path }}.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyfar/gallery/main?labpath={{ introduction_path }})
 {%- endif %}
 
 {{ project_long_description }}

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -5,7 +5,9 @@
 [![PyPI version](https://badge.fury.io/py/{{ project_slug }}.svg)](https://badge.fury.io/py/{{ project_slug }})
 [![Documentation Status](https://readthedocs.org/projects/{{ project_slug }}/badge/?version=latest)](https://{{ project_slug }}.readthedocs.io/en/latest/?badge=latest)
 [![CircleCI](https://circleci.com/gh/{{ git_username }}/{{ project_slug | replace("_", "-") }}.svg?style=shield)](https://circleci.com/gh/{{ git_username }}/{{ project_slug | replace("_", "-") }})
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyfar/gallery/main?labpath=docs/gallery/interactive/pyfar_introduction.ipynb)
+{%- if introduction_path != "" %}
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyfar/gallery/main?labpath=docs/gallery/interactive/{{ introduction_path }}.ipynb)
+{%- endif %}
 
 {{ project_long_description }}
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ def copier_project_defaults():
         "docs_custom_import": "module, anothermodule",
         "add_submodules": "true",
         "submodule_path": "path/to/submodule",
+        "introduction_path": "pyfar_introduction",
         }
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def copier_project_defaults():
         "docs_custom_import": "module, anothermodule",
         "add_submodules": "true",
         "submodule_path": "path/to/submodule",
-        "introduction_path": "pyfar_introduction",
+        "introduction_path": "docs/gallery/interactive/pyfar_introduction.ipynb",
         }
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,8 @@ def copier_project_defaults():
         "docs_custom_import": "module, anothermodule",
         "add_submodules": "true",
         "submodule_path": "path/to/submodule",
-        "introduction_path": "docs/gallery/interactive/pyfar_introduction.ipynb",
+        "introduction_path": "docs/gallery/interactive/"
+        "pyfar_introduction.ipynb",
         }
 
 @pytest.fixture(scope="session")

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -51,6 +51,7 @@ def test_generated_file_exists(default_project, file_name):
     "\nThis is how to get started.\n",
     "\nInstallation instructions.\n",
     "\n\n## Section\n\nSection description.",
+    "https://mybinder.org/v2/gh/pyfar/gallery/main?labpath=docs/gallery/interactive/pyfar_introduction.ipynb",
 ])
 def test_content_readme(default_project, desired):
     content = default_project.project_dir.joinpath("README.md").read_text()


### PR DESCRIPTION
The Binder path for the introduction notebook differs depending on the package, so an option must be added to specify a custom Binder path.

### Changes proposed in this pull request:

- Added a new parameter named `introduction_path` to the `copier.yml`
- The Binder path will be included, only if an `introduction_path` is provided (`introduction_path != ""`)
- Adjusted `README.md`, `conftest.py`, `test_copier.py`
