### PR TITLE
Add new parameter `docs_custom_import` for custom imports in the docs/conf.py

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -140,6 +140,14 @@ manifest_custom:
         Enter a comma-separated list of MANIFEST.in directives to include or exclude files and directories.
         Each entry should follow standard MANIFEST.in syntax.
     default: ""
+
+docs_custom_import:
+    type: str
+    help: |
+        Enter any additional Python modules that should be imported in the docs/conf.py file.
+        Separate multiple modules with commas.
+    default: ""
+
 valid_python_versions:
   when: false
   type: yaml

--- a/template/docs/conf.py.jinja
+++ b/template/docs/conf.py.jinja
@@ -14,6 +14,11 @@ import numpy as np
 sys.path.insert(0, os.path.abspath('..'))
 
 import {{ project_slug }}  # noqa
+{%- for imp in docs_custom_import.split(',') %}
+{%- if imp != "" %}
+import {{ imp.strip() }}
+{%- endif %}
+{%- endfor %}
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ def copier_project_defaults():
         "python_versions": "['3.9', '3.10', '3.11', '3.12', '3.13', '3.14']",
         "manifest_custom": "recursive-include your/custom/path/,"
         "recursive-exclude another/custom/path/'",
+        "docs_custom_import": "module, anothermodule",
         }
 
 @pytest.fixture(scope="session")

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -147,6 +147,8 @@ def test_content_history(default_project):
     'author = "The pyfar developers"',
     "'numpy': ('https://numpy.org/doc/stable/', None)",
     '\n     "index": "my_project.html"',
+    "import module\n"
+    "import anothermodule",
 
 ])
 def test_content_docs_conf(default_project, desired):


### PR DESCRIPTION
The [sofar package](https://github.com/pyfar/sofar/blob/main/docs/conf.py) contains custom imports in the file `docs/conf.py`. With the introduction of the new parameter in `copier.yml`, it should be possible to add multiple custom imports.

### Changes proposed in this pull request:

- Add new parameter named `docs_custom_import` to the `copier.yml` file
- Adjust the `template/docs/conf.py`, `conftest.py`, `test_copier.py` files
