### PR TITLE
Change the version in the links in README.md from `latest` to `stable`

### DIFF
--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -3,7 +3,7 @@
 </h1><br>
 
 [![PyPI version](https://badge.fury.io/py/{{ project_slug }}.svg)](https://badge.fury.io/py/{{ project_slug }})
-[![Documentation Status](https://readthedocs.org/projects/{{ project_slug }}/badge/?version=latest)](https://{{ project_slug }}.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/{{ project_slug }}/badge/?version=stable)](https://{{ project_slug }}.readthedocs.io/en/stable/?badge=stable)
 [![CircleCI](https://circleci.com/gh/{{ git_username }}/{{ project_slug | replace("_", "-") }}.svg?style=shield)](https://circleci.com/gh/{{ git_username }}/{{ project_slug | replace("_", "-") }})
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pyfar/gallery/main?labpath=docs/gallery/interactive/pyfar_introduction.ipynb)
 


### PR DESCRIPTION
I have noticed that the `pyrato` package uses the stable version of the ReadTheDocs website, while all other packages (`pyfar`, `spharpy`, `sofar`) use the latest version. 

### Changes proposed in this pull request:

- Changed the version in the links to ReadTheDocs documentation in the `README.md` file from `latest` to `stable`