### PR TITLE
Fix the problem with empty entries for apt_packages

### DIFF
--- a/template/.readthedocs.yml.jinja
+++ b/template/.readthedocs.yml.jinja
@@ -13,7 +13,9 @@ build:
   {%- if apt_packages != "" %}
   apt_packages:
     {%- for package in apt_packages.split(',') %}
+    {%- if package.strip() != "" %}
     - {{ package.strip() }}
+    {%- endif %}
     {%- endfor %}
   {%- endif %}
 

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -177,7 +177,7 @@ def test_content_docs_multiple_files(default_project, file_name):
 
 @pytest.mark.parametrize("desired", [
     '  apt_packages:\n'
-    '    - libsndfile1',
+    '    - libsndfile1\n\n',
     '    python: "3.14"',
     "  include:\n    - path/to/submodule",
 ])


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

During the [recent update](https://github.com/pyfar/pyfar/pull/927/changes/aebd6cad84780bfa2332f46cd7f43d27a1bae5d9#diff-cde814ef2f549dc093f5b8fc533b7e8f47e7b32a8081e0760e57d5c25a1139d9) of the pyfar package in PR#927 using the template, I noticed that a new entry had been created under `apt_packages` in the `.readthedocs.yml` file, even though there was only one package specified in the copier variable `apt_packages`
<img width="984" height="594" alt="image" src="https://github.com/user-attachments/assets/d59cadbe-291d-4a67-bb0d-fe4e1786dc63" />


### Changes proposed in this pull request:

- Expand the implementation so that entries are not created if they consist only of spaces
- Adjust the tests