### PR TITLE
Fix the `CONTRIBUTING.rst` file for the case the submodules are included

### DIFF
--- a/template/CONTRIBUTING.rst.jinja
+++ b/template/CONTRIBUTING.rst.jinja
@@ -41,18 +41,14 @@ extensions in `Visual Studio Code <https://code.visualstudio.com/>`_ ...
 1. `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo/>`_ the `{{ project_slug }}` repo on GitHub.
 2. Clone your fork locally and cd into the {{ project_slug }} directory::
 
+    $ git clone{%- if add_submodules == true %} --recursive {%- endif %} https://github.com/YOUR_USERNAME/{{ project_slug }}.git
+    $ cd {{ project_slug }}
+
    {%- if add_submodules == true %}
 
-    $ git clone --recursive https://github.com/YOUR_USERNAME/{{ project_slug }}.git
-    $ cd {{ project_slug }}
-   
    Note that some graphical Git interfaces can not do the recursive clone. If the folder {{ submodule_path }} is empty try::
 
     $ git submodule update --init
-   {%- else %}
-
-    $ git clone https://github.com/YOUR_USERNAME/{{ project_slug }}.git
-    $ cd {{ project_slug }}
    {%- endif %}
 
 3. Install your local copy into a virtualenv. Assuming you have Anaconda or Miniconda installed, this is how you set up your fork for local development::

--- a/template/CONTRIBUTING.rst.jinja
+++ b/template/CONTRIBUTING.rst.jinja
@@ -41,15 +41,19 @@ extensions in `Visual Studio Code <https://code.visualstudio.com/>`_ ...
 1. `Fork <https://docs.github.com/en/get-started/quickstart/fork-a-repo/>`_ the `{{ project_slug }}` repo on GitHub.
 2. Clone your fork locally and cd into the {{ project_slug }} directory::
 
-    $ git clone https://github.com/YOUR_USERNAME/{{ project_slug }}.git
-    $ cd {{ project_slug }}
-
    {%- if add_submodules == true %}
+
+    $ git clone --recursive https://github.com/YOUR_USERNAME/{{ project_slug }}.git
+    $ cd {{ project_slug }}
    
    Note that some graphical Git interfaces can not do the recursive clone. If the folder {{ submodule_path }} is empty try::
 
     $ git submodule update --init
-    {%- endif %}
+   {%- else %}
+
+    $ git clone https://github.com/YOUR_USERNAME/{{ project_slug }}.git
+    $ cd {{ project_slug }}
+   {%- endif %}
 
 3. Install your local copy into a virtualenv. Assuming you have Anaconda or Miniconda installed, this is how you set up your fork for local development::
 

--- a/tests/test_copier.py
+++ b/tests/test_copier.py
@@ -86,7 +86,8 @@ def test_license_choice_other(copie, copier_project_defaults):
 
 @pytest.mark.parametrize("desired", [
     "https://github.com/pyfar/my_project/issues",
-    "$ cd my_project",
+    "    $ git clone --recursive https://github.com/YOUR_USERNAME/my_project.git\n"
+    "    $ cd my_project",
     "$ git submodule update --init --recursive",
 ])
 def test_content_contributing(default_project, desired):


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

While updating [sofar](https://github.com/pyfar/sofar/pull/135/changes#diff-76e7ca2f2843ac5f659b45382768c1b64bf8704e8d3c6189c4e3623f5d465bc2L42), I noticed that a line in `CONTRIBUTING.rst` should be implemented differently if the package contains submodules. 

### Changes proposed in this pull request:

- Adjust the `CONTRIBUTING.rst` file so that, if submodules are included, the second step in setting up the project is `$ git clone --recursive (...)`, and if they are not included just `$ git clone (...)`
- Adjust the test function `test_content_contributing()`
